### PR TITLE
Feature: Ability to change word actions position

### DIFF
--- a/src/components/Content/Actions.vue
+++ b/src/components/Content/Actions.vue
@@ -1,10 +1,10 @@
 <template>
-  <div class="actions">
+  <div :class="['actions', `actions--${actionsPosition}`]">
     <IconButton title="Mark as learned" @click="handleMarkAsLearned">
       <i-ic-round-check-circle />
     </IconButton>
 
-    <IconButton title="Mark Word" class="btn-gap" @click="handleMarkWord">
+    <IconButton title="Mark Word" @click="handleMarkWord">
       <i-ic-round-bookmark-add />
     </IconButton>
 
@@ -12,7 +12,6 @@
       :title="`Google translate (${targetLanguage.lang})`"
       :href="`https://translate.google.com/?sl=en&tl=${targetLanguage.code}&text=${definition.word}&op=translate`"
       target="_blank"
-      class="btn-gap"
     >
       <i-ic-round-g-translate />
     </IconButton>
@@ -38,6 +37,7 @@ import IconButton from '@/components/shared/IconButton.vue';
 import useMarkedWords from '@/composables/words/useMarkedWords';
 import useLearnedWords from '@/composables/words/useLearnedWords';
 import useGoogleTranslate from '@/composables/useGoogleTranslate';
+import useWordActionsPosition from '@/composables/useWordActionsPosition';
 
 import { type IWordDefinition } from '@/composables/words/useWordDefinitions';
 
@@ -49,6 +49,7 @@ const emit = defineEmits(['marked']);
 
 const { setWordAsLearned } = useLearnedWords();
 const { targetLanguage } = useGoogleTranslate();
+const { actionsPosition } = useWordActionsPosition();
 const { setWordAsMarked, removeMarkedWord } = useMarkedWords();
 
 const phonetic = computed(() => {
@@ -84,19 +85,23 @@ function handleListen() {
 .actions {
   display: flex;
   align-items: center;
+  gap: 8px;
+  margin: 8px 0;
 }
-
-.btn-gap {
-  margin-left: 8px;
+.actions--HR {
+  flex-direction: row-reverse;
 }
 
 .phonetic {
   display: flex;
   align-items: center;
   margin-left: 12px;
+  gap: 6px;
   font-size: 1.25rem;
 }
-.phonetic__text {
-  margin-right: 6px;
+.actions--HR .phonetic {
+  flex-direction: row-reverse;
+  margin-left: 0;
+  margin-right: 12px;
 }
 </style>

--- a/src/components/Content/Word.vue
+++ b/src/components/Content/Word.vue
@@ -1,6 +1,6 @@
 <template>
   <div class="content">
-    <div class="title">
+    <div :class="['title', `title--${actionsPosition}`]">
       <h1 class="word">{{ word }}</h1>
 
       <Actions
@@ -33,6 +33,7 @@
 import { computed } from 'vue';
 import Actions from './Actions.vue';
 
+import useWordActionsPosition from '@/composables/useWordActionsPosition';
 import type { IWordDefinition } from '@/composables/words/useWordDefinitions';
 
 const props = defineProps<{
@@ -41,6 +42,8 @@ const props = defineProps<{
 }>();
 
 defineEmits(['marked']);
+
+const { actionsPosition } = useWordActionsPosition();
 
 const definition = computed(() => props.definitions?.[0]);
 </script>
@@ -57,6 +60,9 @@ const definition = computed(() => props.definitions?.[0]);
   flex-wrap: wrap;
   justify-content: space-between;
   margin-bottom: 20px;
+}
+.title--V {
+  flex-direction: column;
 }
 
 .word {

--- a/src/composables/useWordActionsPosition.ts
+++ b/src/composables/useWordActionsPosition.ts
@@ -1,0 +1,37 @@
+import storage from '@/modules/localStorage';
+
+const ACTIONS_POSITION_STORAGE_KET = 'ap';
+
+export enum ActionPositions {
+  HORIZONTAL = "H",
+  HORIZONTAL_REVERSED = "HR",
+  VERTICAL = "V"
+}
+
+export const positionToNameMap = {
+  [ActionPositions.HORIZONTAL]: "Horizontal",
+  [ActionPositions.HORIZONTAL_REVERSED]: "Horizontal Reversed",
+  [ActionPositions.VERTICAL]: "Vertical",
+}
+
+export default function useWordActionsPosition() {
+  const actionsPosition = getActionsPositionFromStorage();
+
+  function storeActionsPosition(position: ActionPositions) {
+    storage.set(ACTIONS_POSITION_STORAGE_KET, position)
+  }
+
+  return { actionsPosition, storeActionsPosition }
+}
+
+function getActionsPositionFromStorage(fallbackPosition = ActionPositions.HORIZONTAL): ActionPositions {
+  try {
+    const localPosition = storage.get(ACTIONS_POSITION_STORAGE_KET) as ActionPositions | null;
+
+    const isPositionValid = localPosition && Object.values(ActionPositions).includes(localPosition);
+
+    return isPositionValid ? localPosition : fallbackPosition;
+  } catch {
+    return fallbackPosition;
+  }
+}

--- a/src/options/App.vue
+++ b/src/options/App.vue
@@ -5,12 +5,14 @@
 
     <GoogleTranslate />
     <SiteShortcuts />
+    <WordActionsPosition />
     <VocabularyLists />
     <LearnedWords />
   </div>
 </template>
 
 <script setup lang="ts">
+import WordActionsPosition from './Sections/WordActionsPosition.vue';
 import GoogleTranslate from './Sections/GoogleTranslate.vue';
 import VocabularyLists from './Sections/VocabularyLists.vue';
 import SiteShortcuts from './Sections/SiteShortcuts.vue';

--- a/src/options/App.vue
+++ b/src/options/App.vue
@@ -35,22 +35,4 @@ html {
   margin: 0 auto;
   padding: 0 10px;
 }
-
-.op-section {
-  padding: 10px 0;
-  margin-bottom: 5px;
-}
-.op-section:not(:last-of-type) {
-  border-bottom: 1px solid #eee;
-}
-
-.op-section__title {
-  margin: 0 0 5px;
-  font-size: 1rem;
-}
-.op-section__subtitle {
-  color: #666;
-  font-size: 0.75rem;
-  margin-top: 0;
-}
 </style>

--- a/src/options/Sections/GoogleTranslate.vue
+++ b/src/options/Sections/GoogleTranslate.vue
@@ -7,21 +7,19 @@
       </p>
     </div>
 
-    <select
+    <Select
       v-model="selectedTargetLanguage"
-      class="g-translate__select"
       title="Select target language"
+      :options="options"
       @change="handleSaveGoogleTranslateLanguage"
-    >
-      <option v-for="lang of languages" :key="lang.code" :value="lang">
-        {{ lang.lang }}
-      </option>
-    </select>
+    />
   </div>
 </template>
 
 <script setup lang="ts">
 import { ref } from 'vue';
+
+import Select from '../components/Select.vue';
 
 import useGoogleTranslate from '@/composables/useGoogleTranslate';
 
@@ -33,21 +31,15 @@ const selectedTargetLanguage = ref(targetLanguage);
 function handleSaveGoogleTranslateLanguage() {
   storeTargetLanguageCode(selectedTargetLanguage.value.code);
 }
+
+const options = languages.map((lang) => ({ text: lang.lang, value: lang }));
 </script>
 
-<style>
+<style scoped>
 .g-translate {
   display: flex;
   justify-content: space-between;
   align-items: center;
   flex-wrap: wrap;
-}
-
-.g-translate__select {
-  cursor: pointer;
-  padding: 5px;
-  font-size: 0.9rem;
-  border-radius: 4px;
-  border: 1px solid hsl(0, 0%, 75%);
 }
 </style>

--- a/src/options/Sections/GoogleTranslate.vue
+++ b/src/options/Sections/GoogleTranslate.vue
@@ -1,24 +1,21 @@
 <template>
-  <div class="op-section g-translate">
-    <div>
-      <h2 class="op-section__title">Google Translate</h2>
-      <p class="op-section__subtitle">
-        Change Google translate target language.
-      </p>
-    </div>
-
+  <Section
+    title="Google Translate"
+    description="Change Google translate target language."
+  >
     <Select
       v-model="selectedTargetLanguage"
       title="Select target language"
       :options="options"
       @change="handleSaveGoogleTranslateLanguage"
     />
-  </div>
+  </Section>
 </template>
 
 <script setup lang="ts">
 import { ref } from 'vue';
 
+import Section from '../components/Section.vue';
 import Select from '../components/Select.vue';
 
 import useGoogleTranslate from '@/composables/useGoogleTranslate';
@@ -34,12 +31,3 @@ function handleSaveGoogleTranslateLanguage() {
 
 const options = languages.map((lang) => ({ text: lang.lang, value: lang }));
 </script>
-
-<style scoped>
-.g-translate {
-  display: flex;
-  justify-content: space-between;
-  align-items: center;
-  flex-wrap: wrap;
-}
-</style>

--- a/src/options/Sections/LearnedWords.vue
+++ b/src/options/Sections/LearnedWords.vue
@@ -1,11 +1,9 @@
 <template>
-  <div class="op-section">
-    <h2 class="op-section__title">Learned words</h2>
-    <p class="op-section__subtitle">
-      These are the words that you have marked as "Learned". You can remove them
-      from the list, so they will reappear in a new tab.
-    </p>
-
+  <Section
+    title="Learned words"
+    description='These are the words that you have marked as "Learned". you can remove them from the list, so they will reappear in a new tab.'
+    column
+  >
     <ul v-if="learnedWords.length" class="learned-words">
       <li v-for="word of learnedWords" :key="word" class="word-row">
         <b class="word-row__word">{{ word }}</b>
@@ -19,10 +17,12 @@
       </li>
     </ul>
     <p v-else class="no-learned-word">No learned word yet! 📭</p>
-  </div>
+  </Section>
 </template>
 
 <script setup lang="ts">
+import Section from '../components/Section.vue';
+
 import useLearnedWords from '@/composables/words/useLearnedWords';
 
 const { learnedWords, getLocalLearnedWords, removeLearnedWord } =

--- a/src/options/Sections/SiteShortcuts.vue
+++ b/src/options/Sections/SiteShortcuts.vue
@@ -1,20 +1,18 @@
 <template>
-  <div class="op-section g-translate">
-    <div>
-      <h2 class="op-section__title">Site shortcuts</h2>
-      <p class="op-section__subtitle">
-        Control the visibility of shortcuts sidebar.
-      </p>
-    </div>
-
+  <Section
+    title="Site shortcuts"
+    description="Control the visibility of shortcuts sidebar."
+  >
     <label class="switch">
       <input v-model="isActive" type="checkbox" />
       <span class="slider round" />
     </label>
-  </div>
+  </Section>
 </template>
 
 <script setup lang="ts">
+import Section from '../components/Section.vue';
+
 import useShortcuts from '@/composables/shortcuts/useShortcuts';
 
 const { isActive } = useShortcuts();

--- a/src/options/Sections/VocabularyLists.vue
+++ b/src/options/Sections/VocabularyLists.vue
@@ -1,10 +1,9 @@
 <template>
-  <div class="op-section">
-    <h2 class="op-section__title">Vocabulary lists</h2>
-    <p class="op-section__subtitle">
-      Select the vocabulary lists that you would like to get a random word from.
-    </p>
-
+  <Section
+    title="Vocabulary lists"
+    description="Select the vocabulary lists that you would like to get a random word from."
+    column
+  >
     <ul class="vocab-list">
       <li
         v-for="(listValue, listKey) in WORD_LISTS"
@@ -22,11 +21,13 @@
         </label>
       </li>
     </ul>
-  </div>
+  </Section>
 </template>
 
 <script setup lang="ts">
 import WORD_LISTS from '@/data/words';
+
+import Section from '../components/Section.vue';
 
 import useWordLists from '@/composables/words/useWordLists';
 

--- a/src/options/Sections/WordActionsPosition.vue
+++ b/src/options/Sections/WordActionsPosition.vue
@@ -1,0 +1,38 @@
+<template>
+  <Section
+    title="Word Actions Position"
+    description="Change the actions buttons position based on your preference"
+  >
+    <Select
+      v-model="position"
+      :options="options"
+      title="Select preferred position"
+      @change="handleSaveActionPosition"
+    />
+  </Section>
+</template>
+
+<script setup lang="ts">
+import { ref } from 'vue';
+
+import Select from '../components/Select.vue';
+import Section from '../components/Section.vue';
+
+import useWordActionsPosition, {
+  ActionPositions,
+  positionToNameMap,
+} from '@/composables/useWordActionsPosition';
+
+const options = Object.values(ActionPositions).map((position) => ({
+  text: positionToNameMap[position],
+  value: position,
+}));
+
+const { actionsPosition, storeActionsPosition } = useWordActionsPosition();
+
+const position = ref(actionsPosition);
+
+function handleSaveActionPosition() {
+  storeActionsPosition(position.value);
+}
+</script>

--- a/src/options/components/Section.vue
+++ b/src/options/components/Section.vue
@@ -1,0 +1,54 @@
+<template>
+  <section :class="['section', { 'section--column': column }]">
+    <div>
+      <h2 class="section__title">{{ title }}</h2>
+      <p class="section__description">{{ description }}</p>
+    </div>
+
+    <slot />
+  </section>
+</template>
+
+<script setup lang="ts">
+interface Props {
+  title: string;
+  description: string;
+  column?: boolean;
+}
+
+withDefaults(defineProps<Props>(), {
+  column: false,
+});
+</script>
+
+<style scoped>
+.section {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  flex-wrap: wrap;
+
+  padding: 10px 0;
+  margin-bottom: 5px;
+}
+
+.section--column {
+  flex-direction: column;
+  justify-content: initial;
+  align-items: initial;
+}
+
+.section:not(:last-of-type) {
+  border-bottom: 1px solid #eee;
+}
+
+.section__title {
+  margin: 0 0 5px;
+  font-size: 1rem;
+}
+.section__description {
+  color: #666;
+  font-size: 0.75rem;
+  margin-top: 0;
+}
+</style>

--- a/src/options/components/Select.vue
+++ b/src/options/components/Select.vue
@@ -1,0 +1,53 @@
+<template>
+  <select v-model="value" :title="title" class="select">
+    <option v-for="option of options" :key="option.value" :value="option.value">
+      {{ option.text }}
+    </option>
+  </select>
+</template>
+
+<script setup lang="ts">
+import { computed } from 'vue';
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+type Value = any;
+
+interface Option {
+  value: Value;
+  text: string | number;
+}
+
+interface Props {
+  modelValue: Value;
+  title?: string;
+  options?: Option[];
+}
+
+const props = withDefaults(defineProps<Props>(), {
+  title: '',
+  options: () => [],
+});
+
+const emit = defineEmits<{
+  (e: 'update:modelValue', value: Value): void;
+}>();
+
+const value = computed({
+  get() {
+    return props.modelValue;
+  },
+  set(value: Value) {
+    emit('update:modelValue', value);
+  },
+});
+</script>
+
+<style scoped>
+.select {
+  padding: 5px;
+  border-radius: 4px;
+  border: 1px solid hsl(0, 0%, 75%);
+  font-size: 0.9rem;
+  cursor: pointer;
+}
+</style>


### PR DESCRIPTION
Fixes #18

As described in the issue, giving the ability to change the position of the actions based on preference might be a good option for power users.

Options Page:

![image](https://user-images.githubusercontent.com/20022818/154991553-536ffa1b-5b99-4f87-8afd-4be601c96c53.png)

Horizontal:

![image](https://user-images.githubusercontent.com/20022818/154992209-f16c7358-792b-4630-8c2a-1b0a8a0de6cf.png)

Horizontal Reversed:

![image](https://user-images.githubusercontent.com/20022818/154992284-ce3c7ec8-0d95-454d-a8f8-67eac4c1a742.png)

Vertical:

![image](https://user-images.githubusercontent.com/20022818/154992336-f4349f3c-b928-40de-b981-79ec1f2a243e.png)




The current actions position is kept as the default option.

---

In addition to the new option, other sections of the options page got refactored to make the code more maintainable.